### PR TITLE
Bundle all entry points with rollup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,3 @@
 {
-  "env": {
-    "development": {
-      "presets": [ "@babel/env" ]
-    },
-    "rollup": {
-      "presets": [ ["@babel/env", { "modules": false }] ]
-    },
-    "jsnext": {
-      "presets": [ ["@babel/env", { "modules": false }] ]
-    }
-  }
+  "presets": [ "@babel/env" ]
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /* eslint no-var: 0 */
-var main = require('./dist/commonjs/index.js').default;
+var main = require('./dist/cjs/i18nextChainedBackend.js').default;
 
 module.exports = main;
 module.exports.default = main;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "backend layer for i18next to chain backends",
   "main": "./dist/cjs/i18nextChainedBackend.js",
   "module": "./dist/esm/i18nextChainedBackend.js",
-  "jsnext:main": "./dist/esm/i18nextChainedBackend.js",
   "types": "./index.d.ts",
   "keywords": [
     "i18next",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "i18next-chained-backend",
   "version": "1.0.1",
   "description": "backend layer for i18next to chain backends",
-  "main": "./index.js",
+  "main": "./dist/cjs/i18nextChainedBackend.js",
+  "module": "./dist/esm/i18nextChainedBackend.js",
+  "jsnext:main": "./dist/esm/i18nextChainedBackend.js",
   "types": "./index.d.ts",
-  "jsnext:main": "dist/es/index.js",
   "keywords": [
     "i18next",
     "i18next-backend"
@@ -15,10 +16,12 @@
     "type": "git",
     "url": "https://github.com/i18next/i18next-chained-backend"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@babel/runtime": "^7.4.5"
+  },
   "devDependencies": {
-    "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
+    "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.4.5",
     "babel-eslint": "^10.0.1",
     "babelify": "^10.0.0",
@@ -26,6 +29,7 @@
     "browserify-istanbul": "2.0.0",
     "chai": "3.5.0",
     "coveralls": "2.11.15",
+    "cpy-cli": "^2.0.0",
     "eslint": "3.13.0",
     "eslint-config-airbnb": "13.0.0",
     "i18next": "4.1.4",
@@ -51,23 +55,13 @@
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-node-resolve": "^5.0.1",
     "rollup-plugin-terser": "^5.0.0",
-    "sinon": "1.17.7",
-    "yargs": "6.6.0"
+    "sinon": "1.17.7"
   },
   "scripts": {
     "test": "karma start karma.conf.js --singleRun",
     "tdd": "karma start karma.conf.js",
     "clean": "rimraf dist && mkdirp dist",
-    "copy": "cp ./dist/umd/i18nextChainedBackend.min.js ./i18nextChainedBackend.min.js && cp ./dist/umd/i18nextChainedBackend.js ./i18nextChainedBackend.js",
-    "copy-win": "xcopy .\\dist\\umd\\i18nextChainedBackend.min.js .\\i18nextChainedBackend.min.js /y && xcopy .\\dist\\umd\\i18nextChainedBackend.js .\\i18nextChainedBackend.js /y",
-    "build:es": "BABEL_ENV=jsnext babel src --out-dir dist/es",
-    "build:es-win": "SET BABEL_ENV=jsnext babel src --out-dir dist/es",
-    "build:cjs": "babel src --out-dir dist/commonjs",
-    "build:umd": "rollup -c --format umd",
-    "build:amd": "rollup -c --format amd",
-    "build:iife": "rollup -c --format iife",
-    "build": "npm run clean && npm run build:cjs && npm run build:es && npm run build:umd && npm run copy",
-    "build-win": "npm run clean && npm run build:cjs && npm run build:es-win && npm run build:umd && npm run copy-win",
+    "build": "npm run clean && rollup -c && cpy \"./dist/umd/*.js\" ./",
     "preversion": "npm run test && npm run build && git push",
     "postversion": "git push && git push --tags"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,40 +1,53 @@
 import babel from 'rollup-plugin-babel';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
-import { argv } from 'yargs';
+import pkg from './package.json';
 
-const format = argv.format || argv.f || 'iife';
+const getBabelOptions = ({ useESModules }) => ({
+  exclude: /node_modules/,
+  runtimeHelpers: true,
+  plugins: [
+    ['@babel/transform-runtime', { useESModules }]
+  ]
+});
 
-const babelOptions = {
-  exclude: 'node_modules/**',
-  presets: [['@babel/env', { modules: false }]],
-  babelrc: false
-};
-
-const name = 'i18nextChainedBackend'
+const input = './src/index.js';
+const name = 'i18nextChainedBackend';
+// check relative and absolute paths for windows and unix
+const external = id => !id.startsWith('.') && !id.startsWith('/') && !id.includes(':');
 
 export default [
   {
-    input: './src/index.js',
-    output: {
-      format,
-      name,
-      file: `dist/${format}/${name}.js`
-    },
+    input,
+    output: { format: 'cjs', file: pkg.main },
+    external,
     plugins: [
-      babel(babelOptions),
+      babel(getBabelOptions({ useESModules: false }))
+    ]
+  },
+
+  {
+    input,
+    output: { format: 'esm', file: pkg.module },
+    external,
+    plugins: [
+      babel(getBabelOptions({ useESModules: true }))
+    ]
+  },
+
+  {
+    input,
+    output: { format: 'umd', name, file: `dist/umd/${name}.js` },
+    plugins: [
+      babel(getBabelOptions({ useESModules: true })),
       nodeResolve()
     ],
   },
   {
-    input: './src/index.js',
-    output: {
-      format,
-      name,
-      file: `dist/${format}/${name}.min.js`
-    },
+    input,
+    output: { format: 'umd', name, file: `dist/umd/${name}.min.js` },
     plugins: [
-      babel(babelOptions),
+      babel(getBabelOptions({ useESModules: true })),
       nodeResolve(),
       terser()
     ],


### PR DESCRIPTION
Here's a set of result files
- ./dist/cjs/i18nextChainedBackend.js
- ./dist/esm/i18nextChainedBackend.js
- ./dist/umd/i18nextChainedBackend.js
- ./dist/umd/i18nextChainedBackend.min.js

Amd and iife are part of umd format.

Babel helpers are reused across packages.

Windows specific scripts are simplified.

If you agree I can make PRs in another packages.

Also `jsnext:main` was deprecated a few years ago. It's better to remove in in the next major release.