### PR TITLE
Fix read-callback typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,8 @@
-import { BackendModule, ReadCallback } from "i18next";
+import { BackendModule, type ReadCallback } from "i18next";
+
+export type ChainedReadCallback = (
+  ...args: [...Parameters<ReadCallback>, timestamp?: number]
+) => ReturnType<ReadCallback>;
 
 export interface ChainedBackendOptions {
   /**
@@ -44,7 +48,7 @@ export default class I18NextChainedBackend
   read(
     language: string,
     namespace: string,
-    callback: ReadCallback
+    callback: ChainedReadCallback
   ): void;
   create(
     languages: string[],


### PR DESCRIPTION
Minor fix - typing for ReadCallback is improper, chained-backend expects an optional timestamp for supporting cache
This aligns the read-callback type to match, runtime not affected

reasoning - avoid the following code in typescript:
```
// eslint-disable-next-line @typescript-eslint/no-explicit-any
return (callback as any)(null, data.data, data.i18nStamp);
```